### PR TITLE
Added wp-cli to init, modified object updates.

### DIFF
--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -1,16 +1,27 @@
 FROM debian:buster
 
 # Prep work for gsutils
-RUN apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl cron
+RUN apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl cron 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 
 
 RUN apt-get update && apt-get install -y mariadb-client \
-  wait-for-it google-cloud-sdk
+    wait-for-it google-cloud-sdk \
+    php-cli php-mysql jq && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN curl -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && chmod +x /usr/local/bin/wp
 
 COPY run.sh /run.sh
 COPY backup.sh /backup.sh
+
+# Give init the ability to run wp-cli scripts
+RUN mkdir /etc/wordpress
+COPY wp-config.php /etc/wordpress/wp-config.php
+COPY wp-cli.yml /etc/wordpress/wp-cli.yml
+ENV WP_CLI_CONFIG_PATH=/etc/wordpress/wp-cli.yml
+RUN wp --allow-root core download
 
 COPY backup-cron /etc/cron.d/backup
 COPY backup_entrypoint.sh /backup_entrypoint.sh

--- a/init/run.sh
+++ b/init/run.sh
@@ -11,7 +11,7 @@ shopt -s expand_aliases
 
 # separate db host from port. wp conflates them in its host config variable.
 if [[ $WORDPRESS_DB_HOST =~ ":" ]]; then
-  WORDPRESS_DB_JUST_HOST=$(echo $WORDPRESS_DB_HOST | cut -d ":" -f1)
+	WORDPRESS_DB_JUST_HOST=$(echo $WORDPRESS_DB_HOST | cut -d ":" -f1)
   WORDPRESS_DB_JUST_PORT=$(echo $WORDPRESS_DB_HOST | cut -d ":" -f2)
 else
   WORDPRESS_DB_JUST_HOST=$WORDPRESS_DB_HOST
@@ -25,55 +25,77 @@ wait-for-it $WORDPRESS_DB_JUST_HOST:$WORDPRESS_DB_JUST_PORT -t 0
 if [[ -z "$RUN_INIT" || -z "$DATA_ENV" ]]; then
   echo "Skipping db and media uploads hydration.";
   if [[ -z "$RUN_INIT" ]]; then
-    echo "No RUN_INIT flag found."
+		echo "No RUN_INIT flag found."
   else 
-    echo "DATA_ENV environmental variable is not set."
+		echo "DATA_ENV environmental variable is not set."
   fi
 else
-
+	
   # check database
+	
   DB_HAS_DATA=$(echo "SELECT count(*) FROM information_schema.TABLES WHERE (TABLE_SCHEMA = '${WORDPRESS_DB_DATABASE}') AND (TABLE_NAME = 'wp_options')" | mysql -s )
   if [[ $DB_HAS_DATA = 0 ]]; then
-    echo "No WP data found in db, attempting to pull content for google cloud bucket"
-
-    gcloud auth login --quiet --cred-file=${GOOGLE_APPLICATION_CREDENTIALS}
-    gcloud config set project $GOOGLE_CLOUD_PROJECT
-
-    echo "Downloading: gs://${GOOGLE_CLOUD_BUCKET}/${DATA_ENV}/${MYSQL_DUMP_FILE}"
-    gsutil cp "gs://${GOOGLE_CLOUD_BUCKET}/${DATA_ENV}/${MYSQL_DUMP_FILE}" /$MYSQL_DUMP_FILE
+		echo "No WP data found in db, attempting to pull content for google cloud bucket"
+		
+		gcloud auth login --quiet --cred-file=${GOOGLE_APPLICATION_CREDENTIALS}
+		gcloud config set project $GOOGLE_CLOUD_PROJECT
+		
+		echo "Downloading: gs://${GOOGLE_CLOUD_BUCKET}/${DATA_ENV}/${MYSQL_DUMP_FILE}"
+		gsutil cp "gs://${GOOGLE_CLOUD_BUCKET}/${DATA_ENV}/${MYSQL_DUMP_FILE}" /$MYSQL_DUMP_FILE
 
     echo "Loading sql dump file"
     zcat /$MYSQL_DUMP_FILE | mysql -f
     rm /$MYSQL_DUMP_FILE
-
-    BACKUP_SERVER_URL=$(echo "SELECT option_value from wp_options WHERE option_name='siteurl' LIMIT 1" | mysql -s)
-    echo "Updating links from ${BACKUP_SERVER_URL} to ${WP_SERVER_URL}"
-    
-    mysql -e "update wp_options set option_value='${WP_SERVER_URL}' where option_name='siteurl';"
-    mysql -e "update wp_options set option_value='${WP_SERVER_URL}' where option_name='home';"
-    mysql -e "UPDATE wp_posts SET post_content = REPLACE(post_content, '${BACKUP_SERVER_URL}', '${WP_SERVER_URL}');"
-    mysql -e "UPDATE wp_posts SET guid = REPLACE(guid, '${BACKUP_SERVER_URL}', '${WP_SERVER_URL}');"
-    mysql -e "UPDATE wp_postmeta SET meta_value = REPLACE(meta_value, '${BACKUP_SERVER_URL}', '${WP_SERVER_URL}');"
-
-    if [[ ! -z $SITE_TAGLINE ]]; then
-      mysql -e "update wp_options set option_value='${SITE_TAGLINE}' where option_name='blogdescription';"
-    fi
-
-    echo "Starting full elastic search reindex"
-    curl http://indexer:3000/reindex
-
   else
     echo "WP data found in ${WORDPRESS_DB_JUST_HOST}:${WORDPRESS_DB_JUST_PORT}. Skipping hydration."
-
   fi
 
+  BACKUP_SERVER_URL=$(echo "SELECT option_value from wp_options WHERE option_name='siteurl' LIMIT 1" | mysql -s)
+
+  if [[ ${BACKUP_SERVER_URL} != ${WP_SERVER_URL} ]]; then
+    echo "Updating links from ${BACKUP_SERVER_URL} to ${WP_SERVER_URL}"
+    
+    # WP options
+    mysql -e "update wp_options set option_value='${WP_SERVER_URL}' where option_name='siteurl';"
+    mysql -e "update wp_options set option_value='${WP_SERVER_URL}' where option_name='home';"
+    # First fix objects
+    for obj in $(mysql -s -e "select option_name from wp_options where option_value like 'a:%' and option_value like '%${BACKUP_SERVER_URL}%'"); do
+			new=$(wp --allow-root option --format=json get ${obj} | sed -e "s|${BACKUP_SERVER_URL}|${WP_SERVER_URL}|g")
+			wp --allow-root option update ${obj} "${new}" --format=json
+    done
+    # Then text
+    mysql -e "UPDATE wp_options SET option_value = REPLACE(option_value, '${BACKUP_SERVER_URL}', '${WP_SERVER_URL}');"
+    
+    # POSTS
+    mysql -e "UPDATE wp_posts SET post_content = REPLACE(post_content, '${BACKUP_SERVER_URL}', '${WP_SERVER_URL}');"
+    mysql -e "UPDATE wp_posts SET guid = REPLACE(guid, '${BACKUP_SERVER_URL}', '${WP_SERVER_URL}');"
+    
+    # wp_postmeta
+    # First fix objects
+    for obj in $(mysql -s -e "select concat(post_id,':',meta_key) from wp_postmeta where meta_value like 'a:%' and meta_value like '%${BACKUP_SERVER_URL}%'"); do
+			post_id=${obj%:*}; meta_key=${obj#*:};
+			new=$(wp --allow-root post meta --format=json get ${post_id} ${meta_key} | sed -e "s|${BACKUP_SERVER_URL}|${WP_SERVER_URL}|g")
+			wp --allow-root post meta update ${post_id} ${meta_key} "${new}" --format=json
+    done
+    # Then text
+    mysql -e "UPDATE wp_postmeta SET meta_value = REPLACE(meta_value, '${BACKUP_SERVER_URL}', '${WP_SERVER_URL}');"
+  else
+    echo "${BACKUP_SERVER_URL}=${WP_SERVER_URL} so skipping db updates"
+  fi
+  
+  if [[ ! -z $SITE_TAGLINE ]]; then
+    mysql -e "update wp_options set option_value='${SITE_TAGLINE}' where option_name='blogdescription';"
+  fi
+
+  echo "Starting full elastic search reindex"
+  curl http://indexer:3000/reindex
 
   # check uploads folder
   UPLOADS_FILE_COUNT=$(ls -1q $UPLOADS_DIR | wc -l)
 
   if [[ $UPLOADS_FILE_COUNT == 0 ]]; then
     echo "Uploads folder is empty, attempting to pull content for google cloud bucket"
-  
+		
     # WHY??? 
     gcloud auth login --quiet --cred-file=${GOOGLE_APPLICATION_CREDENTIALS}
     gcloud config set project $GOOGLE_CLOUD_PROJECT

--- a/init/run.sh
+++ b/init/run.sh
@@ -46,6 +46,10 @@ else
     echo "Loading sql dump file"
     zcat /$MYSQL_DUMP_FILE | mysql -f
     rm /$MYSQL_DUMP_FILE
+
+		echo "Starting full elastic search reindex"
+		curl http://indexer:3000/reindex
+
   else
     echo "WP data found in ${WORDPRESS_DB_JUST_HOST}:${WORDPRESS_DB_JUST_PORT}. Skipping hydration."
   fi
@@ -86,9 +90,6 @@ else
   if [[ ! -z $SITE_TAGLINE ]]; then
     mysql -e "update wp_options set option_value='${SITE_TAGLINE}' where option_name='blogdescription';"
   fi
-
-  echo "Starting full elastic search reindex"
-  curl http://indexer:3000/reindex
 
   # check uploads folder
   UPLOADS_FILE_COUNT=$(ls -1q $UPLOADS_DIR | wc -l)

--- a/init/wp-cli.yml
+++ b/init/wp-cli.yml
@@ -1,0 +1,1 @@
+path: /etc/wordpress

--- a/init/wp-config.php
+++ b/init/wp-config.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * The base configuration for WordPress
+ * This has been slightly modified (to read environment variables) for use in Docker.
+ * 
+ * Lifted from the official image: https://github.com/docker-library/wordpress/tree/master/latest
+ * So we can add some UCD customizations without having to shove everything into the WORDPRESS_CONFIG_EXTRA env variable
+ *
+ * @link https://wordpress.org/support/article/editing-wp-config-php/
+ *
+ * @package WordPress
+ */
+
+// IMPORTANT: this file needs to stay in-sync with https://github.com/WordPress/WordPress/blob/master/wp-config-sample.php
+// (it gets parsed by the upstream wizard in https://github.com/WordPress/WordPress/blob/f27cb65e1ef25d11b535695a660e7282b98eb742/wp-admin/setup-config.php#L356-L392)
+
+// a helper function to lookup "env_FILE", "env", then fallback
+if (!function_exists('getenv_docker')) {
+	// https://github.com/docker-library/wordpress/issues/588 (WP-CLI will load this file 2x)
+	function getenv_docker($env, $default) {
+		if ($fileEnv = getenv($env . '_FILE')) {
+			return rtrim(file_get_contents($fileEnv), "\r\n");
+		}
+		else if (($val = getenv($env)) !== false) {
+			return $val;
+		}
+		else {
+			return $default;
+		}
+	}
+}
+
+// ** Database settings - You can get this info from your web host ** //
+/** The name of the database for WordPress */
+define( 'DB_NAME', getenv_docker('WORDPRESS_DB_NAME', 'wordpress') );
+
+/** Database username */
+define( 'DB_USER', getenv_docker('WORDPRESS_DB_USER', 'example username') );
+
+/** Database password */
+define( 'DB_PASSWORD', getenv_docker('WORDPRESS_DB_PASSWORD', 'example password') );
+
+/**
+ * Docker image fallback values above are sourced from the official WordPress installation wizard:
+ * https://github.com/WordPress/WordPress/blob/f9cc35ebad82753e9c86de322ea5c76a9001c7e2/wp-admin/setup-config.php#L216-L230
+ * (However, using "example username" and "example password" in your database is strongly discouraged.  Please use strong, random credentials!)
+ */
+
+/** Database hostname */
+define( 'DB_HOST', getenv_docker('WORDPRESS_DB_HOST', 'mysql') );
+
+/** Database charset to use in creating database tables. */
+define( 'DB_CHARSET', getenv_docker('WORDPRESS_DB_CHARSET', 'utf8') );
+
+/** The database collate type. Don't change this if in doubt. */
+define( 'DB_COLLATE', getenv_docker('WORDPRESS_DB_COLLATE', '') );
+
+/**
+ * WordPress database table prefix.
+ *
+ * You can have multiple installations in one database if you give each
+ * a unique prefix. Only numbers, letters, and underscores please!
+ */
+$table_prefix = getenv_docker('WORDPRESS_TABLE_PREFIX', 'wp_');
+
+if ($configExtra = getenv_docker('WORDPRESS_CONFIG_EXTRA', '')) {
+	eval($configExtra);
+}
+
+/* That's all, stop editing! Happy publishing. */
+
+/** Absolute path to the WordPress directory. */
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/** Sets up WordPress vars and included files. */
+require_once ABSPATH . 'wp-settings.php';


### PR DESCRIPTION
The following PR adds the ability to use wp-cli from the init script.  This allows JSON updates to postmeta and/or options. 
The run.sh has been updated to *always* look for differences between the WP site_url and  the .env SITE_URL. 

This allows patches to things like postmeta redirects and contact info.